### PR TITLE
Adding promises count next to category

### DIFF
--- a/promises_web/templates/category_in_list.html
+++ b/promises_web/templates/category_in_list.html
@@ -6,6 +6,11 @@
       	{{ category }}
 	      
       </h3>
+      	<span>
+      		{% blocktrans with promises_count=category.promises.count %}
+      		{{ promises_count }} promises
+      		{% endblocktrans%}
+      	</span>
       <div class="progress">
 	    <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: {{category.fulfillment_percentage}}%;">
 		    {{category.fulfillment_percentage}}%


### PR DESCRIPTION
As spoken with @camargozzini this pull requests adds the count of how many promises are per category
